### PR TITLE
Fix/controlled autocomplete issue

### DIFF
--- a/src/components/editor/failureMode/FailureModesList.tsx
+++ b/src/components/editor/failureMode/FailureModesList.tsx
@@ -64,7 +64,7 @@ const FailureModesList = ({   label,
                     getContentAnchorEl: null
                 }}
                 onChange={handleChange}
-                renderValue={(selected: any[]) => formatOutput(selected.map(value => value.name).join(", "), 65)}
+                renderValue={(selected: any[]) => formatOutput(selected.filter(v => v).map(value => value.name).join(", "), 65)}
             >
 
                 {(Array.from(allFailureModes.values())).map((failureMode) =>

--- a/src/components/editor/faultTree/Editor.tsx
+++ b/src/components/editor/faultTree/Editor.tsx
@@ -39,6 +39,11 @@ const Editor = ({setAppBarName}: DashboardTitleProps) => {
                 const sidebarEvent = findEventByIri(contextMenuSelectedEvent.iri, faultTree.manifestingEvent);
                 setSidebarSelectedEvent(sidebarEvent)
             }
+
+            if (sidebarSelectedEvent) {
+                const sidebarEvent = findEventByIri(sidebarSelectedEvent.iri, faultTree.manifestingEvent);
+                setSidebarSelectedEvent(sidebarEvent)
+            }
         }
     }, [faultTree])
 

--- a/src/components/editor/system/Editor.tsx
+++ b/src/components/editor/system/Editor.tsx
@@ -92,6 +92,7 @@ const Editor = ({setAppBarName}: DashboardTitleProps) => {
 
     const handleComponentUpdate = (componentToUpdate: Component) => {
         updateComponent(componentToUpdate);
+        setSidebarSelectedComponent(componentToUpdate);
     }
 
     const handleComponentDelete = (componentToDelete: Component) => {

--- a/src/components/editor/system/menu/component/ComponentSidebarMenu.tsx
+++ b/src/components/editor/system/menu/component/ComponentSidebarMenu.tsx
@@ -12,6 +12,7 @@ import {useEffect, useState} from "react";
 import ControlledAutocomplete from "@components/materialui/ControlledAutocomplete";
 import {useForm} from "react-hook-form";
 import {FailureModeProvider} from "@hooks/useFailureModes";
+import {simplifyReferencesOfReferences} from "@utils/utils";
 
 interface Props {
     component: Component,
@@ -32,7 +33,7 @@ const ComponentSidebarMenu = ({component, onComponentUpdated, systemComponents}:
 
     useEffect(() => {
         const c = find(flatten([systemComponents]), el => el.iri === component?.linkedComponent?.iri)
-        setValue('linkedComponent', c)
+        setValue('linkedComponent', c ? simplifyReferencesOfReferences(c) : null)
     }, [linkComponent])
 
     const handleLinkedComponentChange = (linkedComponent: Component | null) => {
@@ -84,6 +85,7 @@ const ComponentSidebarMenu = ({component, onComponentUpdated, systemComponents}:
                     getOptionLabel={(option) => option.name}
                     renderInput={(params) => <TextField {...params} label="Linked Component" variant="outlined"/>}
                     defaultValue={null}
+                    useSafeOptions={true}
                 />
 
             </React.Fragment>}

--- a/src/components/editor/system/menu/function/FunctionsList.tsx
+++ b/src/components/editor/system/menu/function/FunctionsList.tsx
@@ -43,7 +43,7 @@ const FunctionsList = ({label, selectedFunctions, setSelectedFunctions, transiti
                     getContentAnchorEl: null,
                 }}
                 onChange={handleChange}
-                renderValue={(selected: any[]) => formatOutput(selected.map((value) => value.name).join(", "), 50)}
+                renderValue={(selected: any[]) => formatOutput(selected.filter(v => v).map((value) => value.name).join(", "), 50)}
             >
                 {
                     allFunctions.map((f) => (

--- a/src/components/materialui/ControlledAutocomplete.tsx
+++ b/src/components/materialui/ControlledAutocomplete.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {Controller} from "react-hook-form";
 import {Autocomplete} from "@material-ui/lab";
+import {simplifyReferencesOfReferences} from "@utils/utils";
 
 interface Props {
     name: string
@@ -11,26 +12,46 @@ interface Props {
     onChangeCallback?,
     renderOption?: any,
     defaultValue?: any,
+    useSafeOptions?: boolean
 }
 
-const ControlledAutocomplete = ({options = [], name, renderInput, getOptionLabel, control, onChangeCallback, renderOption, defaultValue}: Props) => {
+const ControlledAutocomplete = ({options = [], name, renderInput, getOptionLabel, control, onChangeCallback, renderOption, defaultValue, useSafeOptions = false}: Props) => {
+    let _options = options;
+    let _defaultValue = defaultValue;
+    let _getOptionValue = (data) => data;
+
+    if (useSafeOptions) {
+        const getKey = (o) => o?.iri ? o.iri : o?.uri ? o.uri : null
+            let map: Map<string, any> = new Map()
+        options.forEach(o => map.set(getKey(o), o))
+        _defaultValue = defaultValue ? simplifyReferencesOfReferences(defaultValue) : null
+        _options = options.map(o => simplifyReferencesOfReferences(o))
+        _getOptionValue = (data) => {
+            let key = getKey(data)
+            key ? map.get(key) : data
+        }
+    }
+
+    const getOptionValue = _getOptionValue
+
     return (
         <Controller
             render={({onChange, ...props}) => (
                 <Autocomplete
-                    options={options}
+                    options={_options}
                     getOptionLabel={getOptionLabel}
                     renderOption={renderOption}
                     renderInput={renderInput}
                     onChange={(e, data) => {
-                        onChangeCallback(data)
+                        let _data = getOptionValue(data)
+                        onChangeCallback(_data)
                         onChange(data)
                     }}
                     {...props}
                 />
             )}
             onChange={([, data]) => data}
-            defaultValue={defaultValue}
+            defaultValue={_defaultValue}
             name={name}
             control={control}
         />

--- a/src/components/materialui/ControlledAutocomplete.tsx
+++ b/src/components/materialui/ControlledAutocomplete.tsx
@@ -15,24 +15,28 @@ interface Props {
     useSafeOptions?: boolean
 }
 
-const ControlledAutocomplete = ({options = [], name, renderInput, getOptionLabel, control, onChangeCallback, renderOption, defaultValue, useSafeOptions = false}: Props) => {
-    let _options = options;
-    let _defaultValue = defaultValue;
-    let _getOptionValue = (data) => data;
+const prepareOptions = (useSafeOptions, inputOptions, defaultOption) => {
+    let options = inputOptions;
+    let defaultValue = defaultOption;
+    let getOptionValue = (option) => option;
 
     if (useSafeOptions) {
-        const getKey = (o) => o?.iri ? o.iri : o?.uri ? o.uri : null
-            let map: Map<string, any> = new Map()
+        // make options safe by simplifying their references
+        const getKey = (o) => o?.iri ? o.iri : (o?.uri ? o.uri : null)
+        const map: Map<string, any> = new Map()
         options.forEach(o => map.set(getKey(o), o))
-        _defaultValue = defaultValue ? simplifyReferencesOfReferences(defaultValue) : null
-        _options = options.map(o => simplifyReferencesOfReferences(o))
-        _getOptionValue = (data) => {
+        defaultValue = defaultValue ? simplifyReferencesOfReferences(defaultValue) : null
+        options = options.map(o => simplifyReferencesOfReferences(o))
+        getOptionValue = (data) => {
             let key = getKey(data)
-            key ? map.get(key) : data
+            return key ? map.get(key) : data
         }
     }
+    return [options, defaultValue, getOptionValue]
+}
 
-    const getOptionValue = _getOptionValue
+const ControlledAutocomplete = ({options = [], name, renderInput, getOptionLabel, control, onChangeCallback, renderOption, defaultValue, useSafeOptions = false}: Props) => {
+    const [_options, _defaultValue, getOptionValue] = prepareOptions(useSafeOptions, options, defaultValue)
 
     return (
         <Controller


### PR DESCRIPTION
This pull request fixes several issues two issues causing uncaught exception on the client
1. ControlledAutocomplete for the parent component in component editor throws uncaught exception
2. FailureModesList.tsx and FunctionsList.tsx throw uncaught exception
3. Save buttons should be hidden after submitting changes to components and fault events
@Matthew-Kulich 