### PR TITLE
Disable browser context menu in fault-tree canvas

### DIFF
--- a/src/components/editor/EditorCanvas.styles.tsx
+++ b/src/components/editor/EditorCanvas.styles.tsx
@@ -8,17 +8,14 @@ const useStyles = makeStyles()((theme: Theme) => {
                 display: 'flex',
             },
             konvaContainer: {
-                marginTop: theme.spacing(1),
-                height: `100%`,
+                height: 'calc(100vh - 64px)',
                 flexGrow: 7,
             },
             sidebar: {
-                padding: theme.spacing(1, 0, 0, 1),
-                height: '100%',
+                height: 'calc(100vh - 64px)',
                 overflow: 'hidden',
                 flexGrow: 3,
-                maxWidth: '30%',
-                minWidth: '30%',
+                width: '30%',
             }
         };
     });

--- a/src/components/editor/faultTree/Editor.tsx
+++ b/src/components/editor/faultTree/Editor.tsx
@@ -154,8 +154,12 @@ const Editor = ({setAppBarName}: DashboardTitleProps) => {
         history(ROUTES.FMEA + tableFragment);
     }
 
+    const handleOnContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
+        event.preventDefault();
+    }
+
     return (
-        <React.Fragment>
+        <div onContextMenu={handleOnContextMenu}>
             <EditorCanvas
                 treeName={faultTree?.name}
                 rootEvent={rootEvent}
@@ -189,7 +193,7 @@ const Editor = ({setAppBarName}: DashboardTitleProps) => {
                 faultTreeIri={faultTree?.iri}
                 onCreated={handleFailureModesTableCreated}
                 onClose={() => setFailureModesTableOpen(false)}/>
-        </React.Fragment>
+        </div>
     );
 }
 

--- a/src/components/editor/faultTree/menu/faultEvent/FaultEventContextMenu.tsx
+++ b/src/components/editor/faultTree/menu/faultEvent/FaultEventContextMenu.tsx
@@ -1,7 +1,7 @@
 import {Menu, MenuItem} from "@mui/material";
 import * as React from "react";
-import {EventType} from "../../../../../models/eventModel";
-import {ElementContextMenuAnchor} from "../../../../../utils/contextMenu";
+import {EventType} from "@models/eventModel";
+import {ElementContextMenuAnchor} from "@utils/contextMenu";
 
 interface Props {
     eventType: EventType,


### PR DESCRIPTION
Resolves #142 

Tested in Chrome and Firefox.

FYI @kostobog 