### PR TITLE
[FIX #226] Add missing data for fault event properties

### DIFF
--- a/deploy/shared/db-server/init-data/ava/ava-fta-example-associated-with-fha-fault-event--anonymized.trig
+++ b/deploy/shared/db-server/init-data/ava/ava-fta-example-associated-with-fha-fault-event--anonymized.trig
@@ -10,9 +10,8 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix seq: <http://krizik.felk.cvut.cz/ontologies/2008/6/sequences.owl#> .
+
 <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-tree/instance1443295929> {
-
-
   <http://onto.fel.cvut.cz/ontologies/diagram/rectangle/instance720425674> a diag:rectangle;
     diag:y 0.0E0;
     diag:height 1.0E2;
@@ -50,12 +49,13 @@
     :has-child <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance-741532472>,
       <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance820186229>,
       <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance621415126>,
-      <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance-650995087>;
+      <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance-650995087>,
+      <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1204570762>;
     :has-child-sequence <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_0>;
     :description ""@cs;
     :gate-type "OR"@cs;
     :name "FC 1.1. Tlak v kabině fault event"@cs;
-    :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance833438683> .
+    :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance730041011> .
 
   <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance-741532472>
     a :fault-event, :event;
@@ -72,7 +72,7 @@
     :description ""@cs;
     :name "21-30-01 (pn-11) - Regulator Failure"@cs;
     :probability 1.6667E-5;
-    :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-2004562549> .
+    :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1025504463> .
 
   <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance621415126>
     a :fault-event, :event;
@@ -81,7 +81,7 @@
     :description ""@cs;
     :name "21-30-02 (pn-12) - Control valve Failure"@cs;
     :probability 1.25E-5;
-    :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-147780273> .
+    :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance2071074861> .
 
   <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance-650995087>
     a :fault-event, :event;
@@ -90,13 +90,28 @@
     :description ""@cs;
     :name "21-30-03 (pn-13) - Control and safety valve Failure"@cs;
     :probability 1.667E-5;
-    :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-747419011> .
+    :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-409709365> .
 
   <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-tree/instance1443295929>
     a :fault-tree;
     :is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853>;
     :name "FC 1.1. Tlak v kabině fault event"@cs .
 
+  <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1204570762>
+    a :fault-event;
+    diag:has-rectangle <http://onto.fel.cvut.cz/ontologies/diagram/rectangle/instance1338098093>;
+    :fault-event-type "EXTERNAL"@cs;
+    :description ""@cs;
+    :name "FC_1.3. Tlak v kabině fault event"@cs;
+    :probability 1.0E-1;
+	:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance965534494>.
+  
+  <http://onto.fel.cvut.cz/ontologies/diagram/rectangle/instance1338098093> a diag:rectangle;
+    diag:y 1.8E2;
+    diag:height 1.0E2;
+    diag:x 6.9E2;
+    diag:width 1.0E2 .
+  
   <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_2>
     seq:hasContents <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance621415126>;
     seq1:hasNext <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_3> .
@@ -106,7 +121,8 @@
     seq1:hasNext <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_4> .
 
   <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_4>
-    seq:hasContents <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance-650995087> .
+    seq:hasContents <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance-650995087>;
+    seq1:hasNext <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_5> .
 
   <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_0>
     seq:hasContents <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance-741532472>;
@@ -115,4 +131,25 @@
   <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_1>
     seq:hasContents <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance820186229>;
     seq1:hasNext <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_2> .
+
+  <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1811035853-SEQ_5>
+    seq:hasContents <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1204570762> .
+}
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-tree/instance22467827479333998578> {
+  <http://onto.fel.cvut.cz/ontologies/diagram/rectangle/instance-1583426105> a diag:rectangle .
+  
+  <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-tree/instance22467827479333998578>
+    a :fault-tree;
+    :is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1768303591>;
+    :name "FC_1.3. Tlak v kabině fault event"@cs .
+  
+  <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event/instance1768303591>
+    a :fault-event;
+    diag:has-rectangle <http://onto.fel.cvut.cz/ontologies/diagram/rectangle/instance-1583426105>;
+    :fault-event-type "INTERMEDIATE"@cs;
+    :description ""@cs;
+    :gate-type "OR"@cs;
+    :name "FC_1.3. Tlak v kabině fault event"@cs;
+	:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance965534494>
 }

--- a/deploy/shared/db-server/init-data/ava/sns-partonomy-example--anonymized.ttl
+++ b/deploy/shared/db-server/init-data/ava/sns-partonomy-example--anonymized.ttl
@@ -1,870 +1,906 @@
-@prefix : <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/> .
 @prefix wgs: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
-@prefix dc-terms: <http://purl.org/dc/terms/> .
-@prefix diag: <http://onto.fel.cvut.cz/ontologies/diagram/> .
+@prefix fta: <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix gn: <http://www.geonames.org/ontology#> .
-@prefix seq1: <http://krizik.felk.cvut.cz/ontologies/2008/sequences.owl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix xml: <http://www.w3.org/XML/1998/namespace> .
-@prefix seq: <http://krizik.felk.cvut.cz/ontologies/2008/6/sequences.owl#> .
-
-<http://onto.fel.cvut.cz/ontologies/sns-partonomy-example--anonymized> a owl:Ontology .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-147780273>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance319961958>;
-  :name "pn-12 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance368450851> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance319961958>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1463970910> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1374379334>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-stock "stock-2"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance574662081>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1647268312>;
-  :name "Filter"@cs;
-  :part-number "pn-3"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1525695902>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1032296552>;
-  :name "pn-3 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance574662081> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-737182939>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1416214145>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance7064425>;
-  :name "Filter element"@cs;
-  :part-number "pn-9"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1907114403>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1350881401>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-554744115>;
-  :name "V-band clamp"@cs;
-  :part-number "pn-4"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>
-  a :sns-component;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1726618737>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance440166063>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance974626661>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-11762042>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1372154467>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1740740735>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1478012720>;
-  :has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1157561743>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1138483136>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1378771253>;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-2009429935>;
-  :name "Pressurization control"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1220789846> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1220789846>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Pressurization control"@cs;
-  :ata-code "21-30-00"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-2009429935>
-  a :sns-component;
-  :has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-739730240>;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/system/instance409813372>;
-  :name "Environmental control"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-445002833> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1157561743>
-  a :sns-component;
-  :has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1500157968>;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :name "Control and safety valve"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "Cd5"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance268542990>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance864941407> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1138483136>
-  a :sns-component;
-  :has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1855807217>;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :name "Control valve"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "Cd3"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1114935619>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-12297605> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1378771253>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :name "Regulator"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "Cd1"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-997980844>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance2005638473> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-769756174>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance451711391>;
-  :name "Nut self-locking"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "v TP pozice 1d"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2072121559> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2072121559>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance991954033>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1708268467>;
-  :name "Nut self-locking"@cs;
-  :part-number "pn-5"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance451711391>
-  a :sns-component;
-  :has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-769756174>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-2076639992>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1652772355>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1658414105>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance4307651>;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-739730240>;
-  :name "Filter"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "Ca15"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1374379334>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1553243380> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance-1318429931>
-  a :failure-rate-requirement;
-  :to 4.0E-4 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1463970910>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532>;
-  :value 0.006 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532>
-  a :method;
-  :name "prediction"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-506660391>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532>;
-  :value 0.0003, 0.002 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1045299020>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1712077446>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2032666845>;
-  :name "Gasket is not part of elmnt"@cs;
-  :part-number "pn-8"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance268542990>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Control and safety valve"@cs;
-  :ata-code "21-30-03"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance864941407>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-stock "stock-5"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-843819961>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2042007179>;
-  :name "Control and safety valve"@cs;
-  :part-number "pn-13"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1500157968>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1157561743>;
-  :name "Gasket"@cs;
-  :quantity "1"^^xsd:int;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance810486926> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-747419011>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance923379609>;
-  :name "pn-13 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-843819961> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1813343992>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1230194311>;
-  :name "FC_1.3. Tlak v kabině fault event"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance974626661> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1633594566>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1114935619>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Control valve"@cs;
-  :ata-code "21-30-02"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1549462263>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-962657263> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-962657263>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance679013872>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-2076639992>;
-  :name "Gasket as part of filter elmnt or seprtly"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "v TP pozice 2b"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1250382982> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1250382982>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1973315411>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance399755255>;
-  :name "Gasket as part of filter elmnt or seprtly"@cs;
-  :part-number "pn-6"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-2076639992>
-  a :sns-component;
-  :has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance679013872>;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance451711391>;
-  :name "Filter element"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "2a"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-737182939> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-997980844>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-stock "stock-3"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance600571113>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance36869841>;
-  :name "Regulator"@cs;
-  :part-number "pn-11"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1893577636>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1941359817>;
-  :name "pn-6 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1973315411> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1941359817>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance939892548> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance343241011>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance357860457>;
-  :name "FC_1.5. Tlak v kabině fault event"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1726618737> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance357860457>
-  a :failure-rate;
-  :has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance1369274087> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance143740879>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532>;
-  :value 0.005 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance810486926>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1644314976>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1336634789>;
-  :name "Gasket"@cs;
-  :part-number "pn-1"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1088229207>
-  a :failure-rate;
-  :has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance394472587> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance394472587>
-  a :failure-rate-requirement;
-  :to 1.0E-1 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance923379609>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1465258761> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1465258761>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532>;
-  :value 0.005 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-12297605>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-stock "stock-4"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance368450851>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-874020850>;
-  :name "Control valve"@cs;
-  :part-number "pn-12"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-358767872>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1633594566> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2092414977>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-stock "stock-6"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance260211452>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2048080583>;
-  :name "Air flow limiter"@cs;
-  :part-number "pn-2"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1553243380>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Filter"@cs;
-  :ata-code "21-10-03"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1416272486>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-2027179377>;
-  :name "FC_1.4. Tlak v kabině fault event"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1372154467> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-2027179377>
-  a :failure-rate;
-  :has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance-196082572> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance685683572>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-739730240>;
-  :name "Expansion joint"@cs;
-  :quantity "2"^^xsd:int;
-  :schematic-designation "Ca2"@cs, "Ca20"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1746985035>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1474771785> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1746985035>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-stock "stock-1"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-852955905>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1693863273>;
-  :name "Expansion joint"@cs;
-  :part-number "pn-10"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1474771785>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Expansion joint"@cs;
-  :ata-code "21-10-01"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-739730240>
-  a :sns-component;
-  :has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance451711391>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance685683572>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance39137558>;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-2009429935>;
-  :name "Compression"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-2106939016> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1230194311>
-  a :failure-rate;
-  :has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance576985761> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance576985761>
-  a :failure-rate-requirement;
-  :to 3.0E-3 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1855807217>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1138483136>;
-  :name "Gasket"@cs;
-  :quantity "1"^^xsd:int;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance810486926> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-2106939016>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Compression"@cs;
-  :ata-code "21-10-00"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1598501573>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-926924226>;
-  :name "pn-9 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1416214145> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1420287799>
-  a :reusable-system;
-  :has-type-category "KIND"@cs;
-  :has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1749762934>;
-  :has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance912480440>;
-  :name "Washer"@cs;
-  :part-number "pn-7"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance653050915>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1088229207>;
-  :name "FC_1.6. Tlak v kabině fault event"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1740740735> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1152709347>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1190866796> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1190866796>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-445002833>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Environmental control"@cs;
-  :ata-code "21-00-00"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-926924226>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-809847815> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-809847815>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1712482935>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance791605993>;
-  :name "pn-5 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance991954033> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance791605993>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance2027628092> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance2027628092>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance1369274087>
-  a :failure-rate-requirement;
-  :to 3.0E-3 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1949327257>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1854403521> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1854403521>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1205488611>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1152709347>;
-  :name "fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1644314976> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1475832103>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance791333338>;
-  :name "pn-10 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-852955905> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance791333338>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-12891957> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance752242777>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1949327257>;
-  :name "pn-7 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1749762934> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1691388494>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Air flow limiter"@cs;
-  :ata-code "21-10-02"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance39137558>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-739730240>;
-  :name "Air flow limiter"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "Ca14"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2092414977>,
-    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1691388494> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1752675736>
-  a :failure-rate;
-  :has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance-1318429931> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-2004562549>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-598535435>;
-  :name "pn-11 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance600571113> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-598535435>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance143740879> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-12891957>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance833438683>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1752675736>;
-  :name "FC_1.1. Tlak v kabině fault event"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-11762042> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1032296552>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1683310898> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1683310898>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532>;
-  :value 1.0E-4 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1652772355>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance451711391>;
-  :name "V-band clamp"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "v TP pozice 1e"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1907114403> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1658414105>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance451711391>;
-  :name "Gasket is not part of elmnt"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "v TP pozice 1b"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1045299020> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance4307651>
-  a :sns-component;
-  :is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance451711391>;
-  :name "Washer"@cs;
-  :quantity "1"^^xsd:int;
-  :schematic-designation "v TP pozice 1c"@cs;
-  :is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1420287799> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance559060877>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance256855217>;
-  :name "pn-2 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance260211452> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance256855217>
-  a :failure-rate;
-  :has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-506660391> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-627962029>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-33831121>;
-  :name "FC_1.2. Tlak v kabině fault event"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance440166063> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance-196082572>
-  a :failure-rate-requirement;
-  :to 2.0E-2 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance939892548>
-  a :failure-rate-estimate;
-  :is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/method/instance475143532> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance2005638473>
-  a :ata-system;
-  :has-type-category "ROLE"@cs;
-  :name "Regulator"@cs;
-  :ata-code "21-30-01"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-33831121>
-  a :failure-rate;
-  :has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance625037908> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance625037908>
-  a :failure-rate-requirement;
-  :to 3.0E-3 .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1219952283>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1549462263>;
-  :name "pn-8 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1712077446> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1106124509>
-  a :fault-event-type;
-  :has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-358767872>;
-  :name "pn-4 fails"@cs;
-  :is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1350881401> .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance368450851>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-12297605>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-12 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-874020850>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-147780273>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance574662081>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1374379334>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-3 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1647268312>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1525695902>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1416214145>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-737182939>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-9 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance7064425>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1598501573>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1726618737>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "FC_1.5. Tlak v kabině failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1478012720>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance343241011>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance440166063>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "FC_1.2. Tlak v kabině failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1478012720>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-627962029>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance974626661>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "FC_1.3. Tlak v kabině failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1478012720>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1813343992>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-11762042>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "FC_1.1. Tlak v kabině failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1478012720>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance833438683>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1372154467>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "FC_1.4. Tlak v kabině failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1478012720>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1416272486>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1740740735>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "FC_1.6. Tlak v kabině failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1478012720>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance653050915>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-843819961>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance864941407>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-13 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2042007179>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-747419011>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance600571113>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-997980844>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-11 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance36869841>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-2004562549>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1973315411>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1250382982>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-6 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance399755255>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1893577636>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1644314976>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance810486926>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1336634789>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1205488611>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1350881401>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1907114403>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-4 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-554744115>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1106124509>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1749762934>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1420287799>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-7 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance912480440>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance752242777>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance260211452>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2092414977>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-2 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2048080583>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance559060877>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance991954033>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2072121559>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-5 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1708268467>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1712482935>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-852955905>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1746985035>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-10 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1693863273>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1475832103>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1712077446>
-  a :failure-mode;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1045299020>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-8 failure mode"@cs;
-  :is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2032666845>;
-  :has-manifestation <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1219952283>;
-  :failure-mode-type "FailureMode"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1647268312>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1374379334>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-3 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance7064425>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-737182939>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-9 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-554744115>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1907114403>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-4 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1478012720>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1020422391>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "1.1 Regulace tlaku v kabině"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2032666845>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1045299020>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-8 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2042007179>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance864941407>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-13 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance36869841>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-997980844>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-11 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance399755255>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1250382982>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-6 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1336634789>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance810486926>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-874020850>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-12297605>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-12 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2048080583>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2092414977>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-2 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance912480440>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1420287799>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-7 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1708268467>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2072121559>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-5 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1693863273>
-  a :function;
-  :has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1746985035>;
-  :behavior-type "AtomicBehavior"@cs;
-  :name "pn-10 function"@cs .
-
-<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/system/instance409813372>
-  a :system;
-  :has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-2009429935>;
-  :name "acm1"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1038836157>
+  a fta:fault-event-type;
+  fta:name "pn-10 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1206691011>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance65044440> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance65044440>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1794909063> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1206691011>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1870819537>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1038836157>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1121001373>;
+  fta:name "pn-10 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1188910529>
+  a fta:fault-event-type;
+  fta:name "pn-3 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1406805090>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1277127993> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1277127993>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-419087287> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1406805090>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1656129885>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1188910529>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1744859347>;
+  fta:name "pn-3 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1866474169>
+  a fta:fault-event-type;
+  fta:name "pn-1 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1278157489>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance696383446> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance696383446>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1291421897> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1278157489>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2131962409>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1866474169>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1610018613>;
+  fta:name "pn-1 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2131962409>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1610018613>;
+  fta:name "pn-1 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1610018613>
+  a fta:reusable-system;
+  fta:name "Air flow limiter"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance2131962409>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1278157489>;
+  fta:part-number "pn-1"@cs;
+  fta:stock "stock-6"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-931034165>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance848907161> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance848907161>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1261885194>
+  a fta:reusable-system;
+  fta:name "Expansion joint"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1537620590>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance729856952>;
+  fta:part-number "pn-9"@cs;
+  fta:stock "stock-1"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1537620590>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1261885194>;
+  fta:name "pn-9 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance729856952>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1537620590>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1855412156>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1261885194>;
+  fta:name "pn-9 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance496424052>
+  a fta:sns-component;
+  fta:name "Control valve"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance193210730>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1646551085>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:schematic-designation "Cd3"@cs;
+  fta:quantity "1"^^xsd:int;
+  fta:has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-791804914> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance193210730>
+  a fta:ata-system;
+  fta:name "Control valve"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-30-02"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1646551085>
+  a fta:reusable-system;
+  fta:name "Control valve"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance234210551>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1218201387>;
+  fta:part-number "pn-11"@cs;
+  fta:stock "stock-4"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-791804914>
+  a fta:sns-component;
+  fta:name "Gasket"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance535808345>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance496424052>;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>
+  a fta:sns-component;
+  fta:name "Pressurization control"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1395721073>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1007022414>;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1282834180>;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1314016533>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance47510728>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance298057648>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1782642995>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-218825589>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-2008866423>;
+  fta:has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance496424052>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1840072661>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1446716136> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1840072661>
+  a fta:sns-component;
+  fta:name "Control and safety valve"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance558603459>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1461580193>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:schematic-designation "Cd5"@cs;
+  fta:quantity "1"^^xsd:int;
+  fta:has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1990294353> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance558603459>
+  a fta:reusable-system;
+  fta:name "Control and safety valve"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1520945499>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-771353464>;
+  fta:part-number "pn-12"@cs;
+  fta:stock "stock-5"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1461580193>
+  a fta:ata-system;
+  fta:name "Control and safety valve"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-30-03"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1990294353>
+  a fta:sns-component;
+  fta:name "Gasket"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance2016173277>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1840072661>;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2004977333>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance535808345>;
+  fta:name "pn-13 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance535808345>
+  a fta:reusable-system;
+  fta:name "Gasket"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2004977333>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-600860021>;
+  fta:part-number "pn-13"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1395721073>
+  a fta:ata-system;
+  fta:name "Pressurization control"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-30-00"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1446716136>
+  a fta:sns-component;
+  fta:name "Regulator"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1121001373>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance650530962>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:schematic-designation "Cd1"@cs;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1314016533>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1282834180>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance-860296526>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:name "FC_1.2. Tlak v kabině failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance47510728>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1282834180>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance-1850072769>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:name "FC_1.4. Tlak v kabině failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance298057648>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1282834180>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance273636028>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:name "FC_1.5. Tlak v kabině failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1782642995>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1282834180>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance965534494>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:name "FC_1.3. Tlak v kabině failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-218825589>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1282834180>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance730041011>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:name "FC_1.1. Tlak v kabině failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-2008866423>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1282834180>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance1277688136>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:name "FC_1.6. Tlak v kabině failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1007022414>
+  a fta:sns-component;
+  fta:name "Environmental control"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1216274828>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/system/instance-196155154>;
+  fta:has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1864826487> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1282834180>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1634235068>;
+  fta:name "1.1 Regulace tlaku v kabině"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/system/instance-196155154>
+  a fta:system;
+  fta:name "acm1"@cs;
+  fta:has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1007022414> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-419087287>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265>
+  a fta:failure-rate-general-estimation-method;
+  fta:name "prediction"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1461923300>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance310646763> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance310646763>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1218201387>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance234210551>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1025504463>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1646551085>;
+  fta:name "pn-11 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance234210551>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1646551085>;
+  fta:name "pn-11 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1025504463>
+  a fta:fault-event-type;
+  fta:name "pn-11 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1218201387>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1491721988> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1953954407>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance2016173277>;
+  fta:name "pn-14 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance2016173277>
+  a fta:reusable-system;
+  fta:name "Gasket"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1953954407>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1968200751>;
+  fta:part-number "pn-14"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance-860296526>
+  a fta:fha-fault-event, fta:complex-event-type;
+  fta:name "FC_1.2. Tlak v kabině fault event"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1314016533>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1784221602>;
+  fta:criticality "2"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1784221602>
+  a fta:failure-rate;
+  fta:has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance1039481456> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1855412156>
+  a fta:fault-event-type;
+  fta:name "pn-9 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance729856952>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1461923300> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-444941086>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1691754075> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1691754075>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1121001373>
+  a fta:reusable-system;
+  fta:name "Regulator"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1870819537>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1206691011>;
+  fta:part-number "pn-10"@cs;
+  fta:stock "stock-3"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance650530962>
+  a fta:ata-system;
+  fta:name "Regulator"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-30-01"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance511191455>
+  a fta:sns-component;
+  fta:name "V-band clamp"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1744859347>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1537412609>;
+  fta:schematic-designation "v TP pozice 1e"@cs;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1744859347>
+  a fta:reusable-system;
+  fta:name "V-band clamp"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1656129885>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1406805090>;
+  fta:part-number "pn-3"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1537412609>
+  a fta:sns-component;
+  fta:name "Filter"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1453275009>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1374492073>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1864826487>;
+  fta:schematic-designation "Ca15"@cs;
+  fta:quantity "1"^^xsd:int;
+  fta:has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance511191455>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1080427618>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1922648259>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1268657311>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-114625421> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1491721988>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance1763701236> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance730041011>
+  a fta:fha-fault-event, fta:complex-event-type;
+  fta:name "FC_1.1. Tlak v kabině fault event"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-218825589>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1312347260>;
+  fta:criticality "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1291421897>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265>;
+  fta:value 0.0003 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance1277688136>
+  a fta:fha-fault-event, fta:complex-event-type;
+  fta:name "FC_1.6. Tlak v kabině fault event"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-2008866423>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance463667274>;
+  fta:criticality "2"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance463667274>
+  a fta:failure-rate;
+  fta:has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance-228616624> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1656129885>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1744859347>;
+  fta:name "pn-3 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1510949694>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1392745825>;
+  fta:name "pn-8 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1392745825>
+  a fta:reusable-system;
+  fta:name "Filter element"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1510949694>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-439837882>;
+  fta:part-number "pn-8"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance966598888>
+  a fta:reusable-system;
+  fta:name "Washer"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-367495274>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1321247504>;
+  fta:part-number "pn-6"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-367495274>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance966598888>;
+  fta:name "pn-6 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1321247504>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-367495274>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance735759044>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance966598888>;
+  fta:name "pn-6 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1331907560>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-443868396> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-443868396>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265>;
+  fta:value 0.002 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance-228616624>
+  a fta:failure-rate-requirement;
+  fta:to 1.0E-1 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1654849430>
+  a fta:fault-event-type;
+  fta:name "pn-4 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance934294594>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1418951109> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1418951109>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-2124907212> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance934294594>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2053994623>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1654849430>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-97959065>;
+  fta:name "pn-4 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance1039481456>
+  a fta:failure-rate-requirement;
+  fta:to 3.0E-3 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1080427618>
+  a fta:sns-component;
+  fta:name "Nut self-locking"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-97959065>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1537412609>;
+  fta:schematic-designation "v TP pozice 1d"@cs;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-97959065>
+  a fta:reusable-system;
+  fta:name "Nut self-locking"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2053994623>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance934294594>;
+  fta:part-number "pn-4"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1922648259>
+  a fta:sns-component;
+  fta:name "Gasket is not part of elmnt"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2104860820>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1537412609>;
+  fta:schematic-designation "v TP pozice 1b"@cs;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2104860820>
+  a fta:reusable-system;
+  fta:name "Gasket is not part of elmnt"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-128201740>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-154314784>;
+  fta:part-number "pn-7"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-406269943>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance760221140> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance760221140>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance-1850072769>
+  a fta:fha-fault-event, fta:complex-event-type;
+  fta:name "FC_1.4. Tlak v kabině fault event"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance47510728>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-477085499>;
+  fta:criticality "4"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-477085499>
+  a fta:failure-rate;
+  fta:has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance928619383> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1453275009>
+  a fta:ata-system;
+  fta:name "Filter"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-10-03"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance-942513625>
+  a fta:failure-rate-requirement;
+  fta:to 4.0E-4 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1009204338>
+  a fta:sns-component;
+  fta:name "Air flow limiter"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1610018613>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1666609906>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1864826487>;
+  fta:schematic-designation "Ca14"@cs;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1666609906>
+  a fta:ata-system;
+  fta:name "Air flow limiter"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-10-02"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1864826487>
+  a fta:sns-component;
+  fta:name "Compression"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1928720292>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1007022414>;
+  fta:has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1537412609>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1009204338>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1163555250> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1374492073>
+  a fta:reusable-system;
+  fta:name "Filter"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance706929520>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1450339124>;
+  fta:part-number "pn-2"@cs;
+  fta:stock "stock-2"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance706929520>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1374492073>;
+  fta:name "pn-2 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1450339124>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance706929520>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-881984215>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1374492073>;
+  fta:name "pn-2 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance580629493>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1662965984>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance580629493> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2053994623>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-97959065>;
+  fta:name "pn-4 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance1107816967>
+  a fta:failure-rate-requirement;
+  fta:to 3.0E-3 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance217501636>
+  a fta:sns-component;
+  fta:name "Gasket as part of filter elmnt or seprtly"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1423339238>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1268657311>;
+  fta:schematic-designation "v TP pozice 2b"@cs;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1423339238>
+  a fta:reusable-system;
+  fta:name "Gasket as part of filter elmnt or seprtly"@cs;
+  fta:has-function <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1120352859>;
+  fta:has-type-category "KIND"@cs;
+  fta:has-failure-mode <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance429411771>;
+  fta:part-number "pn-5"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1268657311>
+  a fta:sns-component;
+  fta:name "Filter element"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1392745825>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1537412609>;
+  fta:schematic-designation "2a"@cs;
+  fta:quantity "1"^^xsd:int;
+  fta:has-part-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance217501636> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-439837882>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance1510949694>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1653113263>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1392745825>;
+  fta:name "pn-8 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-952554820>
+  a fta:fault-event-type;
+  fta:name "pn-7 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-154314784>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-406269943> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-154314784>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-128201740>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-952554820>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2104860820>;
+  fta:name "pn-7 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1120352859>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1423339238>;
+  fta:name "pn-5 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance429411771>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1120352859>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1377381721>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1423339238>;
+  fta:name "pn-5 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1312347260>
+  a fta:failure-rate;
+  fta:has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance-942513625> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance-1928720292>
+  a fta:ata-system;
+  fta:name "Compression"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-10-00"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance1163555250>
+  a fta:sns-component;
+  fta:name "Expansion joint"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance1261885194>,
+    <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1760771818>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1864826487>;
+  fta:schematic-designation "Ca2"@cs, "Ca20"@cs;
+  fta:quantity "2"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1008017489>
+  a fta:failure-rate;
+  fta:has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance1107816967> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance735759044>
+  a fta:fault-event-type;
+  fta:name "pn-6 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1321247504>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1272783533> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1272783533>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-220984173> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance654666128>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1147957084>
+  a fta:fault-event-type;
+  fta:name "pn-14 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1968200751>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-931034165> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1968200751>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1953954407>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-1147957084>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance2016173277>;
+  fta:name "pn-14 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance273636028>
+  a fta:fha-fault-event, fta:complex-event-type;
+  fta:name "FC_1.5. Tlak v kabině fault event"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance298057648>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1008017489>;
+  fta:criticality "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-881984215>
+  a fta:fault-event-type;
+  fta:name "pn-2 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance1450339124>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1331907560> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1870819537>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-1121001373>;
+  fta:name "pn-10 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1377381721>
+  a fta:fault-event-type;
+  fta:name "pn-5 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance429411771>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-444941086> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance1763701236>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265>;
+  fta:value 0.006 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1760771818>
+  a fta:ata-system;
+  fta:name "Expansion joint"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-10-01"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-128201740>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance-2104860820>;
+  fta:name "pn-7 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-114625421>
+  a fta:sns-component;
+  fta:name "Washer"@cs;
+  fta:is-derived-from <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance966598888>;
+  fta:is-part-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/sns-component/instance-1537412609>;
+  fta:schematic-designation "v TP pozice 1c"@cs;
+  fta:quantity "1"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance1653113263>
+  a fta:fault-event-type;
+  fta:name "pn-8 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-439837882>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-970460661> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-970460661>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance654666128> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-328140455>
+  a fta:failure-rate;
+  fta:has-prediction <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1874422542> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1874422542>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265>;
+  fta:value 0.005 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance2071074861>
+  a fta:fault-event-type;
+  fta:name "pn-12 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-771353464>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-328140455> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-771353464>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1520945499>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance2071074861>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance558603459>;
+  fta:name "pn-12 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-220984173>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-1794909063>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265>;
+  fta:value 0.005 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/ata-system/instance1216274828>
+  a fta:ata-system;
+  fta:name "Environmental control"@cs;
+  fta:has-type-category "ROLE"@cs;
+  fta:ata-code "21-00-00"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-estimate/instance-2124907212>
+  a fta:failure-rate-estimate;
+  fta:is-based-on <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-general-estimation-method/instance862676265> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-1520945499>
+  a fta:function;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance558603459>;
+  fta:name "pn-12 function"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1368719769>
+  a fta:failure-rate;
+  fta:has-requirement <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance1328582413> .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance1328582413>
+  a fta:failure-rate-requirement;
+  fta:to 3.0E-3 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate-requirement/instance928619383>
+  a fta:failure-rate-requirement;
+  fta:to 2.0E-2 .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fha-fault-event/instance965534494>
+  a fta:fha-fault-event, fta:complex-event-type;
+  fta:name "FC_1.3. Tlak v kabině fault event"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-1782642995>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance-1368719769>;
+  fta:criticality "3"^^xsd:int .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-600860021>
+  a fta:failure-mode;
+  fta:is-impairing <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/function/instance-2004977333>;
+  fta:is-manifested-by <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-409709365>;
+  fta:failure-mode-type "FailureMode"@cs;
+  fta:has-component <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/reusable-system/instance535808345>;
+  fta:name "pn-13 failure mode"@cs;
+  fta:behavior-type "AtomicBehavior"@cs .
+
+<http://onto.fel.cvut.cz/ontologies/fta-fmea-application/fault-event-type/instance-409709365>
+  a fta:fault-event-type;
+  fta:name "pn-13 fails"@cs;
+  fta:is-manifestation-of <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-mode/instance-600860021>;
+  fta:has-failure-rate <http://onto.fel.cvut.cz/ontologies/fta-fmea-application/failure-rate/instance1662965984> .


### PR DESCRIPTION
Partially fixes #226
- add criticality in sns partonomy
- add external reference node to fta example - Fixes #219