### PR TITLE
Fixed node info causing app to crash

### DIFF
--- a/src/components/dialog/faultEvent/FaultEventCreation.tsx
+++ b/src/components/dialog/faultEvent/FaultEventCreation.tsx
@@ -111,8 +111,8 @@ const FaultEventCreation = ({ useFormMethods, isRootEvent }: Props) => {
                       labelId="event-type-select-label"
                       label={t("newFtaModal.type")}
                     >
-                      {Object.values(EventType).map((value) => (
-                        <MenuItem key={value} value={value}>
+                      {Object.values(EventType).map((value, index) => (
+                        <MenuItem key={index} value={value}>
                           {value}
                         </MenuItem>
                       ))}

--- a/src/components/editor/faultTree/menu/faultEvent/FaultEventMenu.tsx
+++ b/src/components/editor/faultTree/menu/faultEvent/FaultEventMenu.tsx
@@ -103,8 +103,7 @@ const FaultEventMenu = ({ shapeToolData, onEventUpdated, refreshTree, rootIri }:
 
   return (
     <Box paddingLeft={2} marginRight={2}>
-      {/* Hidden to prevent app crush after root node select (Bug with UI).Related to issue #331. Will be fixed in next PR */}
-      {/*<FaultEventShapeToolPane data={shapeToolData} onEventUpdated={onEventUpdated} refreshTree={refreshTree} />*/}
+      <FaultEventShapeToolPane data={shapeToolData} onEventUpdated={onEventUpdated} refreshTree={refreshTree} />
 
       {/* TODO: Finish for other nodes. Will be refactored. */}
 

--- a/src/components/editor/faultTree/menu/faultEvent/FaultEventShapeToolPane.tsx
+++ b/src/components/editor/faultTree/menu/faultEvent/FaultEventShapeToolPane.tsx
@@ -13,6 +13,7 @@ import { FaultEvent, GateType } from "@models/eventModel";
 import FaultEventChildrenReorderList from "@components/editor/faultTree/menu/faultEvent/reorder/FaultEventChildrenReorderList";
 import { SnackbarType, useSnackbar } from "@hooks/useSnackbar";
 import useStyles from "@components/editor/faultTree/menu/faultEvent/FaultEventShapeToolPane.styles";
+import { FaultEventsReuseProvider } from "@hooks/useReusableFaultEvents";
 
 interface Props {
   data?: FaultEvent;
@@ -52,7 +53,11 @@ const FaultEventShapeToolPane = ({ data, onEventUpdated, refreshTree }: Props) =
       onEventUpdated(dataClone);
     };
 
-    editorPane = <FaultEventCreation useFormMethods={useFormMethods} eventReusing={false} />;
+    editorPane = (
+      <FaultEventsReuseProvider>
+        <FaultEventCreation useFormMethods={useFormMethods} isRootEvent={true}/>
+      </FaultEventsReuseProvider>
+    );
   } else {
     defaultValues = {};
     useFormMethods = useForm();


### PR DESCRIPTION
Resolves #316 

App is no longer crashing when clicking on a node to display info. However, it is still impossible to update a node (described in #352).

@Kasmadei FYI