### PR TITLE
#385 Avoid stack overflow exception by removing value of existingEvent from default values in update fault event form.

### DIFF
--- a/src/components/editor/faultTree/menu/faultEvent/FaultEventShapeToolPane.tsx
+++ b/src/components/editor/faultTree/menu/faultEvent/FaultEventShapeToolPane.tsx
@@ -40,11 +40,6 @@ const FaultEventShapeToolPane = ({ data, onEventUpdated, refreshTree }: Props) =
       probability: data.probability ? data.probability : 0.01,
       gateType: data.gateType ? data.gateType : null,
       sequenceProbability: data.sequenceProbability,
-      existingEvent: Array.isArray(data.supertypes)
-        ? data.supertypes.length > 0
-          ? data.supertypes[0]
-          : null
-        : data.supertypes,
     };
 
     useFormMethods = useForm({


### PR DESCRIPTION
@blcham 
Fixing another blank screen error when selecting fault event.
Fixes reopened #385 