### PR TITLE
397 Fix fault event update does not remove event type when new event is selected

### DIFF
--- a/src/components/dialog/faultEvent/FaultEventCreation.tsx
+++ b/src/components/dialog/faultEvent/FaultEventCreation.tsx
@@ -32,6 +32,7 @@ const FaultEventCreation = ({ useFormMethods, isRootEvent, eventValue, isEditedE
   } = useFormMethods;
 
   const faultEvents = useReusableFaultEvents();
+  const [newEvent, setNewEvent] = useState<String | null>(null);
   const [selectedEvent, setSelectedEvent] = useState<FaultEvent | null>(null);
   const [showCreateEvent, setShowCreateEvent] = useState(false);
   const existingEventSelected = Boolean(selectedEvent);
@@ -52,10 +53,12 @@ const FaultEventCreation = ({ useFormMethods, isRootEvent, eventValue, isEditedE
 
   const handleFilterOptions = (inputValue) => {
     const filtered = faultEvents.filter((option) => option.name.toLowerCase().includes(inputValue.toLowerCase()));
+    setNewEvent(inputValue);
     setFilteredOptions(filtered);
   };
 
   const handleOnCreateEventClick = (e: MouseEvent) => {
+    setSelectedEvent({ name: newEvent });
     setShowCreateEvent(true);
   };
 


### PR DESCRIPTION
@blcham 
partially fixes #397

This solution has the following bug:
- changing the event type of fault event is persisted but the form shows the old value. This is fixed after the event node is selected again.