### PR TITLE
Feature/310 min operational hours

### DIFF
--- a/src/components/editor/faultTree/Editor.tsx
+++ b/src/components/editor/faultTree/Editor.tsx
@@ -21,6 +21,7 @@ import { JOINTJS_NODE_MODEL } from "@components/editor/faultTree/shapes/constant
 import { calculateCutSets } from "@services/faultTreeService";
 import { FaultEventScenario } from "@models/faultEventScenario";
 import { useAppBar } from "../../../contexts/AppBarContext";
+import { asArray } from "@utils/utils";
 
 const Editor = () => {
   const history = useNavigate();
@@ -58,7 +59,7 @@ const Editor = () => {
       setRootEvent(updatedRootEvent);
 
       if (faultTree.faultEventScenarios) {
-        setFaultEventScenarios([getScenarioWithHighestProbability(faultTree.faultEventScenarios)]);
+        setFaultEventScenarios([getScenarioWithHighestProbability(asArray(faultTree.faultEventScenarios))]);
       }
 
       if (contextMenuSelectedEvent) {
@@ -256,7 +257,7 @@ const Editor = () => {
           setHighlightedElement={setHighlightedElementView}
           refreshTree={refreshTree}
           faultEventScenarios={faultEventScenarios}
-          possibleFaultEventScenarios={faultTree?.faultEventScenarios ? faultTree?.faultEventScenarios : []}
+          possibleFaultEventScenarios={asArray(faultTree?.faultEventScenarios)}
           showPath={showPath}
           showTable={showTable}
           onScenarioSelect={(scenario: FaultEventScenario) => handleOnScenarioSelect(scenario)}

--- a/src/components/editor/faultTree/Editor.tsx
+++ b/src/components/editor/faultTree/Editor.tsx
@@ -181,7 +181,7 @@ const Editor = () => {
   const handleCutSetAnalysis = () => {
     setShowPath(!showPath);
     setShowTable(!showTable);
-    calculateCutSets(faultTree.iri)
+    calculateCutSets(faultTree.iri, faultTree.operationalDataFilter)
       .then((d) => {
         refreshTree();
       })

--- a/src/models/faultTreeModel.tsx
+++ b/src/models/faultTreeModel.tsx
@@ -2,14 +2,16 @@ import VocabularyUtils from "@utils/VocabularyUtils";
 import { FaultEvent, CONTEXT as EVENT_CONTEXT } from "@models/eventModel";
 import { AbstractModel, CONTEXT as ABSTRACT_CONTEXT } from "@models/abstractModel";
 import { FaultEventScenario, CONTEXT as SCENARIO_CONTEXT } from "@models/faultEventScenario";
+import { OperationalDataFilter, CONTEXT as FILTER_CONTEXT } from "@models/operationalDataFilterModel";
 
 const ctx = {
   manifestingEvent: VocabularyUtils.PREFIX + "is-manifested-by",
   faultEventScenarios: VocabularyUtils.PREFIX + "has-scenario",
+  operationalDataFilter: VocabularyUtils.PREFIX + "has-operational-data-filter",
   name: VocabularyUtils.PREFIX + "name",
 };
 
-export const CONTEXT = Object.assign({}, ctx, ABSTRACT_CONTEXT, EVENT_CONTEXT, SCENARIO_CONTEXT);
+export const CONTEXT = Object.assign({}, ctx, ABSTRACT_CONTEXT, EVENT_CONTEXT, SCENARIO_CONTEXT, FILTER_CONTEXT);
 
 export interface FaultTree extends AbstractModel {
   name: string;
@@ -29,4 +31,5 @@ export interface FaultTree extends AbstractModel {
   subSystem?: {
     name?: string;
   };
+  operationalDataFilter: OperationalDataFilter;
 }

--- a/src/models/operationalDataFilterModel.tsx
+++ b/src/models/operationalDataFilterModel.tsx
@@ -1,0 +1,12 @@
+import VocabularyUtils from "@utils/VocabularyUtils";
+import { AbstractModel, CONTEXT as ABSTRACT_CONTEXT } from "@models/abstractModel";
+
+const ctx = {
+  minOperationalHours: VocabularyUtils.PREFIX + "min-operational-hours",
+};
+
+export const CONTEXT = Object.assign({}, ctx, ABSTRACT_CONTEXT);
+
+export interface OperationalDataFilter extends AbstractModel {
+  minOperationalHours: number;
+}

--- a/src/models/systemModel.tsx
+++ b/src/models/systemModel.tsx
@@ -1,15 +1,20 @@
 import VocabularyUtils from "@utils/VocabularyUtils";
 import { Component, CONTEXT as COMPONENT_CONTEXT } from "@models/componentModel";
 import { AbstractModel, CONTEXT as ABSTRACT_CONTEXT } from "@models/abstractModel";
+import { OperationalDataFilter, CONTEXT as FILTER_CONTEXT } from "@models/operationalDataFilterModel";
 
 const ctx = {
   name: VocabularyUtils.PREFIX + "name",
+  globalOperationalDataFilter: VocabularyUtils.PREFIX + "has-global-operational-data-filter",
+  operationalDataFilter: VocabularyUtils.PREFIX + "has-operational-data-filter",
   components: VocabularyUtils.PREFIX + "has-part-component",
 };
 
-export const CONTEXT = Object.assign({}, ctx, COMPONENT_CONTEXT, ABSTRACT_CONTEXT);
+export const CONTEXT = Object.assign({}, ctx, COMPONENT_CONTEXT, ABSTRACT_CONTEXT, FILTER_CONTEXT);
 
 export interface System extends AbstractModel {
   name: string;
   components?: Component[];
+  globalOperationalDataFilter: OperationalDataFilter;
+  operationalDataFilter: OperationalDataFilter;
 }

--- a/src/services/faultTreeService.tsx
+++ b/src/services/faultTreeService.tsx
@@ -3,6 +3,7 @@ import { authHeaders } from "@services/utils/authUtils";
 import axiosClient from "@services/utils/axiosUtils";
 import { CONTEXT, FaultTree } from "@models/faultTreeModel";
 import { CONTEXT as EVENT_CONTEXT, FaultEvent } from "@models/eventModel";
+import { CONTEXT as FILTER_CONTEXT, OperationalDataFilter } from "@models/operationalDataFilterModel";
 import VocabularyUtils from "@utils/VocabularyUtils";
 import { extractFragment } from "@services/utils/uriIdentifierUtils";
 import {
@@ -198,10 +199,12 @@ export const getTreePathsAggregate = async (): Promise<[FaultEvent[]]> => {
   }
 };
 
-export const calculateCutSets = async (faultTreeUri: string) => {
+export const calculateCutSets = async (faultTreeUri: string, operationalDataFilter: OperationalDataFilter) => {
   try {
     const fragment = extractFragment(faultTreeUri);
-    const response = await axiosClient.put(`/faultTrees/${fragment}/evaluate`, null, {
+    const filter = Object.assign({}, operationalDataFilter, { "@context": FILTER_CONTEXT });
+
+    const response = await axiosClient.put(`/faultTrees/${fragment}/evaluate`, filter, {
       headers: authHeaders(),
     });
     return response;

--- a/src/utils/VocabularyUtils.tsx
+++ b/src/utils/VocabularyUtils.tsx
@@ -16,4 +16,5 @@ export default {
   SYSTEM: _NS_FTA_FMEA + "system",
   FAILURE_MODES_TABLE: _NS_FTA_FMEA + "failure-modes-table",
   FAILURE_MODES_ROW: _NS_FTA_FMEA + "failure-modes-row",
+  OPERATIONAL_DATA_FILTER: _NS_FTA_FMEA + "operational-data-filter",
 };


### PR DESCRIPTION
@blcham 
Implement model and request calls to backend API regarding minimal operational hours.
This is related to backend PR kbss-cvut/fta-fmea#119 which implements the backend API 
of persistent minimal operational hours.

This should give access `OperationalDataFilter.minOperationalHours` in fault tree and system objects.

