### PR TITLE
Fix/minor fault event update bugs

### DIFF
--- a/src/components/dialog/component/ComponentPicker.tsx
+++ b/src/components/dialog/component/ComponentPicker.tsx
@@ -44,6 +44,7 @@ const ComponentPicker = ({ selectedComponent, onComponentSelected }: Props) => {
         name={"component"}
         fullWidth
         options={components}
+        getOptionKey={(option) => option.iri}
         getOptionLabel={(option) => option.name}
         onChangeCallback={(value: Component) => onComponentSelected(value)}
         renderInput={(params) => <TextField {...params} label="Select Component" variant="outlined" />}

--- a/src/components/dialog/faultEvent/FaultEventCreation.tsx
+++ b/src/components/dialog/faultEvent/FaultEventCreation.tsx
@@ -78,6 +78,7 @@ const FaultEventCreation = ({ useFormMethods, isRootEvent, eventValue, isEditedE
           onChangeCallback={(data: any) => setSelectedEvent(data)}
           onInputChangeCallback={handleFilterOptions}
           onCreateEventClick={handleOnCreateEventClick}
+          getOptionKey={(option) => option.iri}
           getOptionLabel={(option) => option.name}
           renderInput={(params) => (
             <TextField {...params} label={t("newFtaModal.eventPlaceholder")} variant="outlined" {...register("name")} />

--- a/src/components/editor/faultTree/menu/faultEvent/FaultEventShapeToolPane.tsx
+++ b/src/components/editor/faultTree/menu/faultEvent/FaultEventShapeToolPane.tsx
@@ -15,6 +15,7 @@ import { SnackbarType, useSnackbar } from "@hooks/useSnackbar";
 import useStyles from "@components/editor/faultTree/menu/faultEvent/FaultEventShapeToolPane.styles";
 import { ReusableFaultEventsProvider } from "@hooks/useReusableFaultEvents";
 import { useCurrentFaultTree } from "@hooks/useCurrentFaultTree";
+import { asArray } from "@utils/utils";
 
 interface Props {
   data?: FaultEvent;
@@ -33,6 +34,7 @@ const FaultEventShapeToolPane = ({ data, onEventUpdated, refreshTree }: Props) =
   let defaultValues;
 
   if (data) {
+    const safeSupertype = asArray(data.supertypes).map((t) => ({ name: t.name, iri: t.iri, types: t.types }))?.[0];
     defaultValues = {
       eventType: data.eventType,
       name: data.name,
@@ -40,6 +42,7 @@ const FaultEventShapeToolPane = ({ data, onEventUpdated, refreshTree }: Props) =
       probability: data.probability ? data.probability : 0.01,
       gateType: data.gateType ? data.gateType : null,
       sequenceProbability: data.sequenceProbability,
+      existingEvent: safeSupertype,
     };
 
     useFormMethods = useForm({

--- a/src/components/editor/system/menu/component/ComponentSidebarMenu.tsx
+++ b/src/components/editor/system/menu/component/ComponentSidebarMenu.tsx
@@ -97,6 +97,7 @@ const ComponentSidebarMenu = ({ component, onComponentUpdated, systemComponents 
             name="linkedComponent"
             options={allowedComponents}
             onChangeCallback={handleLinkedComponentChange}
+            getOptionKey={(option) => option.iri}
             getOptionLabel={(option) => option.name}
             renderInput={(params) => <TextField {...params} label="Linked Component" variant="outlined" />}
             defaultValue={null}

--- a/src/components/materialui/ControlledAutocomplete.tsx
+++ b/src/components/materialui/ControlledAutocomplete.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 interface Props {
   name: string;
   options: any[];
+  getOptionKey: (any) => string;
   getOptionLabel: (any) => string;
   renderInput;
   control;
@@ -46,6 +47,7 @@ const ControlledAutocomplete = ({
   options = [],
   name,
   renderInput,
+  getOptionKey,
   getOptionLabel,
   control,
   onChangeCallback,
@@ -88,6 +90,7 @@ const ControlledAutocomplete = ({
         <Autocomplete
           fullWidth
           options={_options}
+          getOptionKey={getOptionKey}
           getOptionLabel={getOptionLabel}
           renderOption={renderOption}
           renderInput={renderInput}

--- a/src/services/faultEventService.tsx
+++ b/src/services/faultEventService.tsx
@@ -27,7 +27,7 @@ export const findAll = async (): Promise<FaultEvent[]> => {
 
 export const update = async (faultEvent: FaultEvent): Promise<void> => {
   try {
-    const updateRequest = Object.assign({}, faultEvent, { "@context": EVENT_CONTEXT });
+    const updateRequest = simplifyReferencesOfReferences(Object.assign({}, faultEvent, { "@context": EVENT_CONTEXT }));
 
     await axiosClient.put("/faultEvents", updateRequest, {
       headers: authHeaders(),


### PR DESCRIPTION
@blcham 

This PR solves several minor bugs related to fault event update:
- a23f615cc4bf7bd4450e5a2ce244399ef6282801 - fix warnings caused by options with same name in autocomplete component by providing a option key
- 8a0fb6170739339f901974ee21ea7d9aa3d9f1e5 - fix fault event `supertypes` is set to null when fault event is updated but the autocomplete is not used to select a new or the same event type.
- 221f554f44d49257f3213058ce86cf96e65eabfc - fix error when executing fault event update 