### PR TITLE
Prevent of sending selectedEstimate for M rate

### DIFF
--- a/src/components/editor/faultTree/menu/faultEvent/FaultEventMenu.tsx
+++ b/src/components/editor/faultTree/menu/faultEvent/FaultEventMenu.tsx
@@ -98,9 +98,13 @@ const FaultEventMenu = ({ shapeToolData, onEventUpdated, refreshTree, rootIri }:
 
   const handleManualFailureRateUpdate = (eventType: EventType) => {
     if (eventType === EventType.EXTERNAL) {
-      onEventUpdated({ ...shapeToolData, probability: externalManuallyDefinedFailureRate });
+      onEventUpdated({
+        ...shapeToolData,
+        probability: externalManuallyDefinedFailureRate,
+        selectedEstimate: undefined,
+      });
     } else {
-      onEventUpdated({ ...shapeToolData, probability: snsManuallyDefinedFailureRate });
+      onEventUpdated({ ...shapeToolData, probability: snsManuallyDefinedFailureRate, selectedEstimate: undefined });
     }
   };
 

--- a/src/components/editor/faultTree/menu/faultEvent/FaultEventMenu.tsx
+++ b/src/components/editor/faultTree/menu/faultEvent/FaultEventMenu.tsx
@@ -97,15 +97,14 @@ const FaultEventMenu = ({ shapeToolData, onEventUpdated, refreshTree, rootIri }:
   };
 
   const handleManualFailureRateUpdate = (eventType: EventType) => {
-    if (eventType === EventType.EXTERNAL) {
-      onEventUpdated({
-        ...shapeToolData,
-        probability: externalManuallyDefinedFailureRate,
-        selectedEstimate: undefined,
-      });
-    } else {
-      onEventUpdated({ ...shapeToolData, probability: snsManuallyDefinedFailureRate, selectedEstimate: undefined });
-    }
+    const probability =
+      eventType === EventType.EXTERNAL ? externalManuallyDefinedFailureRate : snsManuallyDefinedFailureRate;
+
+    onEventUpdated({
+      ...shapeToolData,
+      probability,
+      selectedEstimate: undefined,
+    });
   };
 
   const handleFailureModeClicked = (failureMode: FailureMode) => {


### PR DESCRIPTION
Fixes https://github.com/kbss-cvut/fta-fmea-ui/issues/457

As I noticed, there is no need to send selectedEstimate as a prop of the node after manual f. rate was selected.