### PR TITLE
 Fix call to evaluate fault tree with updated value of minOperationalHours

### DIFF
--- a/src/components/editor/faultTree/canvas/EditorCanvas.tsx
+++ b/src/components/editor/faultTree/canvas/EditorCanvas.tsx
@@ -289,7 +289,10 @@ const EditorCanvas = ({
   };
 
   const handleSetNewDefaultOperationalHours = () => {
-    calculateCutSets(faultTree.iri, faultTree.operationalDataFilter)
+    const newOperationalDataFilter = Object.assign({}, faultTree.operationalDataFilter);
+    newOperationalDataFilter.minOperationalHours =
+      updatedMinOperationalHours || faultTree.operationalDataFilter.minOperationalHours;
+    calculateCutSets(faultTree.iri, newOperationalDataFilter)
       .then((d) => {
         refreshTree();
       })


### PR DESCRIPTION
@blcham 
Fix partially #428

Fixes call to fault tree evaluated with old value of minOperationalHours