### PR TITLE
Gate fix (server update) + save/discard fix

### DIFF
--- a/src/components/dialog/faultEvent/FaultEventCreation.tsx
+++ b/src/components/dialog/faultEvent/FaultEventCreation.tsx
@@ -149,7 +149,7 @@ const FaultEventCreation = ({
                     labelId="gate-type-select-label"
                     label={t("newFtaModal.gateType")}
                     error={!!errors.gateType}
-                    disabled={disabled}
+                    disabled={isEditMode && !(eventValue?.eventType === EventType.INTERMEDIATE)}
                   >
                     {gateTypeValues()
                       .filter((value) => value[0])

--- a/src/components/editor/faultTree/menu/faultEvent/FaultEventMenu.tsx
+++ b/src/components/editor/faultTree/menu/faultEvent/FaultEventMenu.tsx
@@ -93,9 +93,10 @@ const FaultEventMenu = ({ shapeToolData, onEventUpdated, refreshTree, rootIri }:
   const [snsPredictedIri, setSnsPredictedIri] = useState<string | undefined>(undefined);
 
   const handleOnSave = async () => {
+    setShowSaveAndRejectButton(false);
     const values = getValues();
-    const { description } = values;
-    const updateEvent = async (data) => await onEventUpdated({ ...shapeToolData, ...data, description });
+    const { description, gateType } = values;
+    const updateEvent = async (data) => await onEventUpdated({ ...shapeToolData, ...data, gateType, description });
 
     const eventTypeData = {
       [RadioButtonType.Predicted]: { iri: snsPredictedIri, value: snsPredictedFailureRate },
@@ -308,7 +309,7 @@ const FaultEventMenu = ({ shapeToolData, onEventUpdated, refreshTree, rootIri }:
       {/* ROOT NODE */}
       {shapeToolData && shapeToolData.iri === rootIri && (
         <>
-          <Typography className={classes.labelRow}>
+          <Typography className={classes.eventPropertyRow}>
             <span className={classes.label}>{`${t("faultEventMenu.eventName")}: `}</span>
             {shapeToolData.name}
           </Typography>


### PR DESCRIPTION
@blcham @LaChope 
Fixes: 

1) For new event creation gate is not disabled
2) Gate now successfully updates with server
3) save/discard partly fixed.

Problem: Open any event with a gate, change the gate without saving (just in the dropdown), then change it back. The Save/Discard buttons are still visible, but the value in the gate dropdown is reset to its initial state. It's unclear why isDirty remains true even after the value has been reverted.