### PR TITLE
Fix renaming fault tree

### DIFF
--- a/src/components/dialog/faultTree/FaultTreeEditDialog.tsx
+++ b/src/components/dialog/faultTree/FaultTreeEditDialog.tsx
@@ -36,9 +36,9 @@ const FaultTreeEditDialog = ({ open, handleCloseDialog, faultTree }: Props) => {
   const handleCreateFaultTree = async (values: any) => {
     setIsProcessing(true);
 
-    faultTree.name = values.faultTreeName;
-    await updateTree(faultTree);
+    await updateTree(Object.assign({}, faultTree, { name: values.faultTreeName }));
 
+    faultTree.name = values.faultTreeName;
     setIsProcessing(false);
     handleCloseDialog();
   };

--- a/src/services/faultTreeService.tsx
+++ b/src/services/faultTreeService.tsx
@@ -61,7 +61,9 @@ export const create = async (faultTree: FaultTree): Promise<FaultTree> => {
 export const update = async (faultTree: FaultTree): Promise<FaultTree> => {
   try {
     const updateRequest = Object.assign({}, faultTree, { "@context": CONTEXT });
-
+    updateRequest.calculatedFailureRate = null;
+    updateRequest.fhaBasedFailureRate = null;
+    updateRequest.requiredFailureRate = null;
     const response = await axiosClient.put("/faultTrees", updateRequest, {
       headers: authHeaders(),
     });


### PR DESCRIPTION
@blcham 
Fixes renaming of fault trees:
- fixes request body deserialization issue - remove failure rate property values from request body to avoid number conversion (BigDecimal to Double) during deserialization.
- Update fault tree name in UI only after successful update request