### PR TITLE
Fix moh reset button in fault tree editor

### DIFF
--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -47,7 +47,11 @@
   "diagramSidePanel": {
     "cutsetToggleToolTip": "Přepnout do pohledu řezu",
     "minimumOperationalHours": "Min. provozní doba",
-    "diagramOptions": "Možnosti diagramu"
+    "diagramOptions": "Možnosti diagramu",
+    "messages": {
+      "mohNewValue": "Nová hodnota, která se není použíta při vyhodnocování stromu chyb.",
+      "mohExperimental": "Hodnota se liší od min. hodnota provozní hodiny systému."
+    }
   },
   "faultEventScenariosTable": {
     "cutset": "Řez",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -47,7 +47,11 @@
   "diagramSidePanel": {
     "cutsetToggleToolTip": "Switch to cutsets view",
     "minimumOperationalHours": "Min. operational hours",
-    "diagramOptions": "Diagram Options"
+    "diagramOptions": "Diagram Options",
+    "messages": {
+      "mohNewValue": "New value, not used in fault tree evaluation.",
+      "mohExperimental": "Value is different from the system's min. operational hour value."
+    }
   },
   "faultEventScenariosTable": {
     "cutset": "Cutset",

--- a/src/models/faultTreeModel.tsx
+++ b/src/models/faultTreeModel.tsx
@@ -3,18 +3,28 @@ import { FaultEvent, CONTEXT as EVENT_CONTEXT } from "@models/eventModel";
 import { AbstractModel, CONTEXT as ABSTRACT_CONTEXT } from "@models/abstractModel";
 import { FaultEventScenario, CONTEXT as SCENARIO_CONTEXT } from "@models/faultEventScenario";
 import { OperationalDataFilter, CONTEXT as FILTER_CONTEXT } from "@models/operationalDataFilterModel";
-import { System } from "@models/systemModel";
+import { System, CONTEXT as SYSTEM_CONTEXT } from "@models/systemModel";
 import { Status } from "@utils/constants";
 
 const ctx = {
   manifestingEvent: VocabularyUtils.PREFIX + "is-manifested-by",
   faultEventScenarios: VocabularyUtils.PREFIX + "has-scenario",
   operationalDataFilter: VocabularyUtils.PREFIX + "has-operational-data-filter",
+  system: VocabularyUtils.PREFIX + "is-artifact-of",
+  subSystem: VocabularyUtils.PREFIX + "is-performed-by",
   name: VocabularyUtils.PREFIX + "name",
   status: VocabularyUtils.PREFIX + "status",
 };
 
-export const CONTEXT = Object.assign({}, ctx, ABSTRACT_CONTEXT, EVENT_CONTEXT, SCENARIO_CONTEXT, FILTER_CONTEXT);
+export const CONTEXT = Object.assign(
+  {},
+  ctx,
+  ABSTRACT_CONTEXT,
+  EVENT_CONTEXT,
+  SCENARIO_CONTEXT,
+  FILTER_CONTEXT,
+  SYSTEM_CONTEXT,
+);
 
 export interface FaultTree extends AbstractModel {
   name: string;


### PR DESCRIPTION
@blcham 
Fix #593

Fixes behavior of MOH input field and its refresh button.

The screen shots below show how the MOH input field is rendered based on three variables, 
- value of field MOH (`MOH`), 
- fault tree MOH (`ftMoh `) and
-  system MOH (`sMOH`).

The style of MOH field uses orange color for the value of the MOH filed to distinguish if `MOH `is different from `sMOH `and orange color to of the border of the field to distinguish if `MOH` different from `ftMOH`. The field also has localized hint(s) to show 


`1) MOH = ftMoh and MOH = sMOH`
![image](https://github.com/user-attachments/assets/c44b5a8e-ddc1-4003-98a5-4264b84acdba)

`2) MOH != ftMoh and MOH != sMOH` - e.g. user updated MOH the value in the field 
![image](https://github.com/user-attachments/assets/747dfb79-1bb0-482e-ba64-3bf498b30a99)

`3) MOH = ftMoh and MOH != sMOH` - e.g. user evaluated tree with MOH != sMOH
![image](https://github.com/user-attachments/assets/521ba7fa-7fcc-4e43-987b-8019c93462b4)

`4) MOH != ftMoh and MOH = sMOH`  - e.g. user updated MOH to be equal to sMOH
![image](https://github.com/user-attachments/assets/55de7a3f-30ea-4adf-a6c1-1aa772b32bc4)


The reset button updates the MOH value. Note that the reset button does not persist MOH (i.e. does not set ftMOH by calling server api) and it does not evaluate fault tree with MOH. The reset button works as follows based on the current state MOH, ftMOH and sMOH:
`1) MOH = ftMoh and MOH = sMOH`
 - do nothing
`2) MOH != ftMoh  and MOH != sMOH` or  `4) MOH != ftMoh and MOH = sMOH`
-  MOH := ftMoh
`3) MOH = ftMoh and MOH != sMOH`
- MOH := sMOH - sets MOH to sMOH

User 
