### PR TITLE
Fix fault tree editor layout

### DIFF
--- a/src/components/dashboard/Dashboard.styles.tsx
+++ b/src/components/dashboard/Dashboard.styles.tsx
@@ -3,11 +3,7 @@ import { Theme } from "@mui/material";
 
 const useStyles = makeStyles()((theme: Theme) => {
   return {
-    root: {
-      display: "flex",
-      flexFlow: "column",
-      height: "100vh",
-    },
+    root: {},
     fab: {
       zIndex: 5,
       position: "absolute",

--- a/src/components/navigation/Navigation.styles.tsx
+++ b/src/components/navigation/Navigation.styles.tsx
@@ -9,8 +9,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     overflow: "hidden",
   },
   childrenContainer: {
-    display: "flex",
-    flexDirection: "column",
+    display: "block",
     overflow: "hidden",
     flex: "1",
     zIndex: 1,

--- a/src/components/navigation/Navigation.styles.tsx
+++ b/src/components/navigation/Navigation.styles.tsx
@@ -3,8 +3,7 @@ import { Theme } from "@mui/material";
 
 const useStyles = makeStyles()((theme: Theme) => ({
   container: {
-    display: "flex",
-    flexDirection: "column",
+    display: "block",
     alignItems: "stretch",
     height: "100vh",
     overflow: "hidden",


### PR DESCRIPTION
@blcham 
Fix #644
Fix fault tree editor layout:
- fix canvas and sidebar overlapped by top title bar
- fix missplaced outdated message count indicator for  calculated failure rate in root node