### PR TITLE
Fix message count indicator layout 

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -19,7 +19,7 @@ export const syncProblemIcon = (message: any, messageCount = 1) => {
 export const iconWithMessage = (icon, message: any, label: string | number = "") => {
   return (
     <Tooltip title={message}>
-      {icon} {<span style={{ verticalAlign: "top", position: "fixed" }}>{label}</span>}
+      {icon} {<span style={{ verticalAlign: "top", marginLeft: "-5px" }}>{label}</span>}
     </Tooltip>
   );
 };


### PR DESCRIPTION
@blcham 
Fix #644 
Fix message count indicator layout for the calculated failure rate column in fault tree overview table.